### PR TITLE
feat(time): add optional chrony sources.d drop-ins without changing legacy behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Configuration of timezone and ntp settings
 |`timezone_area` | `Europe` | Timezone area |
 |`timezone` | `Zurich` | Exact timezone (area needs to match) |
 |`ntp_servers` | `["time.ethz.ch", "swisstime.ethz.ch"]` | Timeservers. Note that these are only guaranteed to be accessible from inside ETH's network, so you might need to specify different ones. |
+|`ntp_sources_dir` | `/etc/chrony/sources.d` | Directory for optional Chrony source drop-ins. |
+|`ntp_sources_files` | `[]` | Optional list of drop-in files and server lists to render as `server ... iburst` lines. |
+
+### Proxmox 9 / Debian Trixie drop-in example
+
+Keep existing role behavior (`ntp_servers` still drives `chrony.conf`) and add source drop-ins:
+
+```yaml
+time_client_override: chrony
+ntp_sources_files:
+  - name: ethz.sources
+    servers: [time.ethz.ch, time6.ethz.ch]
+  - name: swiss.sources
+    servers: [0.ch.pool.ntp.org, 1.ch.pool.ntp.org, 2.ch.pool.ntp.org, 3.ch.pool.ntp.org]
+```
 
 ## License
 GPLv3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,14 @@ timezone: Zurich
 ntp_servers:
   - time.ethz.ch
   - swisstime.ethz.ch
+
+# Optional Chrony drop-in source files.
+# The legacy ntp_servers-based chrony.conf remains managed as before.
+ntp_sources_dir: /etc/chrony/sources.d
+
+# List of drop-in source files to manage.
+# Example:
+# ntp_sources_files:
+#   - name: ethz.sources
+#     servers: [time.ethz.ch, time6.ethz.ch]
+ntp_sources_files: []

--- a/tasks/chrony.yml
+++ b/tasks/chrony.yml
@@ -22,6 +22,29 @@
   notify:
     - Restart chronyd
 
+- name: Ensure chrony sources.d exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ ntp_sources_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: ntp_sources_files | length > 0
+
+- name: Install chronyd source drop-ins
+  become: true
+  ansible.builtin.template:
+    src: chrony_source_file.j2
+    dest: "{{ ntp_sources_dir }}/{{ item.name }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ ntp_sources_files }}"
+  notify:
+    - Restart chronyd
+  when: ntp_sources_files | length > 0
+
 - name: Enable chronyd
   become: true
   ansible.builtin.service:


### PR DESCRIPTION
Keep the existing ntp_servers flow unchanged so chrony.conf is still managed as before. Add optional ntp_sources_dir and ntp_sources_files variables to support chrony sources.d drop-in files. When ntp_sources_files is set, create the sources directory and render each file as server ... iburst entries.

Why:
Debian Trixie prefers drop-in Chrony source files, but existing hosts should keep current behavior with no migration required.